### PR TITLE
Change concatting only .part2/3 to concat multiple parts. (up to 10)

### DIFF
--- a/root/patch
+++ b/root/patch
@@ -1,5 +1,5 @@
 --- casper      2020-04-08 21:24:58.000000000 +0000
-+++ casper.new  2020-04-23 17:13:23.139096816 +0000
++++ casper.new  2025-03-04 16:22:09.000000000 +0000
 @@ -46,7 +46,7 @@ parse_cmdline() {
                      STATICIP="frommedia"
                  fi
@@ -27,16 +27,18 @@
 -                umount $mountpoint
 -            fi
 -        fi
+-    fi
 +    mkdir -p ${mountpoint}
 +    mount -t tmpfs -o size=`/bin/curl -sI ${URL} | sed -ne '/Content-Length/{s/.*: //;p}'` tmpfs ${mountpoint}
 +    mkdir -p ${mountpoint}/casper
 +    if /bin/curl -L ${URL} -o ${mountpoint}/casper/root.squashfs; then rc=0; fi
-+    if [ ! -z "$(/bin/curl -sI "${URL}".part2 | grep "200 OK\|302 Found" || :)" ]; then
-+        if /bin/curl -L ${URL}.part2 -o ->> ${mountpoint}/casper/root.squashfs; then rc=0; fi
-+    fi
-+    if [ ! -z "$(/bin/curl -sI "${URL}".part3 | grep "200 OK\|302 Found" || :)" ]; then
-+        if /bin/curl -L ${URL}.part3 -o ->> ${mountpoint}/casper/root.squashfs; then rc=0; fi
-     fi
--
++    for n in $(seq 2 10); do
++      if [ ! -z "$(/bin/curl -sI "${URL}.part${n}" | grep "200 OK\|302 Found" || :)" ]; then
++        if /bin/curl -L "${URL}.part${n}" -o ->> ${mountpoint}/casper/root.squashfs; then rc=0; fi
++      else
++        break
++      fi
++    done
+
      return ${rc}
  }


### PR DESCRIPTION
Addresses netbootxyz/netboot.xyz#1588, fixes Ubuntu before it needs more than 3 parts.

(I tried to manually write the .patch, might be a smidge off)